### PR TITLE
Adding direction auto for fpreporter.

### DIFF
--- a/app/src/html/Templates/fpreporter.html
+++ b/app/src/html/Templates/fpreporter.html
@@ -1,14 +1,14 @@
-<div class="page-header">
+<div class="page-header" dir="auto">
 	<h1>{{{fpreporter}}}</h1>
 </div>
-<div id="page1" style="display:{{{{page1displaytoggle}}}}">
+<div id="page1" style="display:{{{{page1displaytoggle}}}}" dir="auto">
 	{{{fpreporterinstructions}}}
 	<br>
 	<br>
 	<b>{{{fpreporterinstructions1}}}</b>
 	<form id="fpinputform" name="fpinputform" method="post" action="index.php?page=reportfalsepositive">
 		<textarea autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="form-control"
-		          rows="9" id="fplist" name="fplist" autofocus>{{{{fplistvalue}}}}</textarea>
+		          rows="9" id="fplist" name="fplist" dir="ltr" autofocus>{{{{fplistvalue}}}}</textarea>
 		<input type="submit" value="{{{submit}}}" class="btn btn-primary"
 		       onclick="this.value='{{{checking}}}…';document.getElementById('loadingmessage').style.display='block';this.disabled=true;this.form.submit();"/>
 		<div id="loadingmessage" style="display:none" aria-live="assertive">


### PR DESCRIPTION
To support Right-To-Left (RTL) languages, set the dir to auto.
Dir auto will set the direction based on content so for RTL languages,
that have translated the relevant part, it will show in right direction.

The change applies only to tpreporter page - can be added later to more
pages.