### PR TITLE
Allow a namespace other than ns0 to be passed as a parameter through …

### DIFF
--- a/app/src/Core/APII.php
+++ b/app/src/Core/APII.php
@@ -851,6 +851,7 @@ class API {
 	 *
 	 * @param int $limit How many articles to return in a batch
 	 * @param array $resume Where to resume in the batch retrieval process
+	 * @param int $namespace Which namespace the bot should operate in
 	 *
 	 * @access public
 	 * @static
@@ -859,7 +860,7 @@ class API {
 	 * @copyright Copyright (c) 2015-2020, Maximilian Doerr, Internet Archive
 	 * @author Maximilian Doerr (Cyberpower678)
 	 */
-	public static function getAllArticles( $limit, array $resume ) {
+	public static function getAllArticles( $limit, array $resume, $namespace=0 ) {
 		$returnArray = [];
 		if( is_null( self::$globalCurl_handle ) ) self::initGlobalCurlHandle();
 		while( true ) {
@@ -867,7 +868,7 @@ class API {
 				'action'        => 'query',
 				'list'          => 'allpages',
 				'format'        => 'json',
-				'apnamespace'   => 0,
+				'apnamespace'   => $namespace,
 				'apfilterredir' => 'nonredirects',
 				'aplimit'       => $limit - count( $returnArray )
 			];

--- a/app/src/deadlink.php
+++ b/app/src/deadlink.php
@@ -19,7 +19,7 @@ if( !empty( $argv[1] ) ) {
 	$parts = explode(':', $argv[1]);
 	echo "Set to run on {$parts[0]}\n";
 	define( 'WIKIPEDIA', $parts[0] );
-	if ( $parts[1] ) {
+	if ( !empty( $parts[1] ) ) {
 		$namespace = intval($parts[1]);
 		echo "Namespace set to {$parts[1]}";
 	}

--- a/app/src/deadlink.php
+++ b/app/src/deadlink.php
@@ -1,6 +1,6 @@
 <?php
 /*
-	Copyright (c) 2015-2020, Maximilian Doerr, Internet Archive
+	Copyright (c) 2015-2020, Maximilian Doerr, James Hare, Internet Archive
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
@@ -14,9 +14,15 @@
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 */
+$namespace = 0;
 if( !empty( $argv[1] ) ) {
-	echo "Set to run on {$argv[1]}\n";
-	define( 'WIKIPEDIA', $argv[1] );
+	$parts = explode(':', $argv[1]);
+	echo "Set to run on {$parts[0]}\n";
+	define( 'WIKIPEDIA', $parts[0] );
+	if ( $parts[1] ) {
+		$namespace = intval($parts[1]);
+		echo "Namespace set to {$parts[1]}";
+	}
 }
 if( !empty( $argv[2] ) ) {
 	echo "ID set to {$argv[2]}\n";
@@ -142,12 +148,13 @@ while( true ) {
 			echo "Fetching";
 			if( DEBUG === true && is_int( $debugStyle ) && LIMITEDRUN === false ) echo " " . $debugStyle;
 			echo " article pages...\n";
+
 			if( DEBUG === true && is_int( $debugStyle ) && LIMITEDRUN === false ) {
-				$pages = API::getAllArticles( 5000, $return );
+				$pages = API::getAllArticles( 5000, $return, $namespace );
 				$return = $pages[1];
 				$pages = $pages[0];
 			} elseif( $iteration !== 1 || $pages === false ) {
-				$pages = API::getAllArticles( 5000, $return );
+				$pages = API::getAllArticles( 5000, $return, $namespace );
 				$return = $pages[1];
 				$pages = $pages[0];
 				file_put_contents( IAPROGRESS . "runfiles/" . WIKIPEDIA . UNIQUEID . "c",


### PR DESCRIPTION
…':n' after the database name, e.g.  to run deadlink in namespace 6 on commonswiki.