### PR TITLE
Add Wikimedia domain validation for oauth returnto url

### DIFF
--- a/app/src/html/Includes/actionfunctions.php
+++ b/app/src/html/Includes/actionfunctions.php
@@ -2910,3 +2910,43 @@ function submitBotJob( &$jsonOut = false ) {
 			"This parameter is a newline separated list of page titles as recognized by the MW parser that is required for this request.";
 	}
 }
+
+/**
+ * Test whether a url's host is a valid wikimedia domain.
+ * Based upon https://git.io/JqFeO, see also: T276915.
+ *
+ * @param string url to validate
+ *
+ * @return bool
+*/
+function validateWikimediaDomain( string $url ): bool {
+	$allowedDomains = [
+		'wikipedia.org',
+		'wiktionary.org',
+		'wikibooks.org',
+		'wikinews.org',
+		'wikiquote.org',
+		'wikisource.org',
+		'wikiversity.org',
+		'wikivoyage.org',
+		'wikimedia.org',
+		'wikidata.org',
+		'mediawiki.org',
+	];
+
+	$validAllowedDomain = false;
+
+	if( (bool)filter_var( $url, FILTER_VALIDATE_URL ) ) {
+		$urlParsed = parse_url( $url, PHP_URL_SCHEME ) . '://' .
+			parse_url( $url, PHP_URL_HOST );
+		foreach( $allowedDomains as $d ) {
+			$rePat = "/^https?:\/\/(.*\.)?{$d}$/";
+			if( preg_match( $rePat, $urlParsed ) ) {
+				$validAllowedDomain = true;
+				break;
+			}
+		}
+	}
+
+	return (bool)$validAllowedDomain;
+}

--- a/app/src/html/Includes/actionfunctions.php
+++ b/app/src/html/Includes/actionfunctions.php
@@ -2932,6 +2932,7 @@ function validateWikimediaDomain( string $url ): bool {
 		'wikimedia.org',
 		'wikidata.org',
 		'mediawiki.org',
+		'toolforge.org',
 	];
 
 	$validAllowedDomain = false;

--- a/app/src/html/oauthcallback.php
+++ b/app/src/html/oauthcallback.php
@@ -42,8 +42,15 @@ if( isset( $_GET['oauth_verifier'] ) && $_GET['oauth_verifier'] && $oauth->getOA
 	} else {
 		$url .= "?returnedfrom=oauthcallback";
 	}
-	header( "Location: $url" );
-	exit( 0 );
+
+	if( validateWikimediaDomain( $_GET['returnto'] ) ) {
+		header( "Location: $url" );
+		exit( 0 );
+	}
+	else {
+		$errMsg = 'Invalid returnto domain provided ('.htmlentities( $_GET['returnto'] ).')';
+		throw new DomainException( $errMsg );
+	}
 }
 
 if( isset( $_GET['action'] ) || isset( $_POST['action'] ) ) {


### PR DESCRIPTION
Validate oauth "returnto" to urls to be valid "Wikimedia"
domains.  Based upon the Wikimedia URL shortener (https://w.wiki/yM)
allow list, see: https://git.io/JqFeO.

Bug: https://phabricator.wikimedia.org/T276915