### PR TITLE
T299576

### DIFF
--- a/app/src/Core/init.php
+++ b/app/src/Core/init.php
@@ -238,6 +238,17 @@ if( !isset( $accessibleWikis[WIKIPEDIA] ) ) {
 $language = $accessibleWikis[WIKIPEDIA]['language'];
 
 if( isset( $accessibleWikis[WIKIPEDIA]['disabled'] ) ) {
+	if( isset( $_SESSION['previouswiki'] ) ) {
+		@header( "HTTP/1.1 307 Temporary Redirect", true, 307 );
+		@header( "Location: index.php?wiki={$_SESSION['previouswiki']}&missingwikierror=1",
+		         true, 307
+		);
+	} else {
+		@header( "HTTP/1.1 307 Temporary Redirect", true, 307 );
+		@header( "Location: index.php?wiki=$defaultWiki&missingwikierror=1",
+		         true, 307
+		);
+	}
 	echo "This wiki is disabled.";
 	exit( 1 );
 }

--- a/app/src/Core/init.php
+++ b/app/src/Core/init.php
@@ -237,6 +237,14 @@ if( !isset( $accessibleWikis[WIKIPEDIA] ) ) {
 }
 $language = $accessibleWikis[WIKIPEDIA]['language'];
 
+require_once( IABOTROOT . 'Core/APII.php' );
+
+//Check if the wiki is closed
+if( API::isWikiClosed( WIKIPEDIA ) ) {
+	$accessibleWikis[WIKIPEDIA]['disabled'] = true;
+	DB::setConfiguration( "global", "systemglobals-allwikis", WIKIPEDIA, $accessibleWikis[WIKIPEDIA] );
+}
+
 if( isset( $accessibleWikis[WIKIPEDIA]['disabled'] ) ) {
 	if( isset( $_SESSION['previouswiki'] ) ) {
 		@header( "HTTP/1.1 307 Temporary Redirect", true, 307 );
@@ -255,7 +263,6 @@ if( isset( $accessibleWikis[WIKIPEDIA]['disabled'] ) ) {
 
 if( !isset( $runpage ) ) $runpage = $accessibleWikis[WIKIPEDIA]['runpage'];
 
-require_once( IABOTROOT . 'Core/APII.php' );
 require_once( IABOTROOT . 'Core/parse.php' );
 require_once( IABOTROOT . 'Core/generator.php' );
 require_once( IABOTROOT . 'Core/ISBN.php' );

--- a/app/src/html/Includes/HTMLLoader.php
+++ b/app/src/html/Includes/HTMLLoader.php
@@ -366,6 +366,7 @@ class HTMLLoader {
 		$intList = [];
 		$intListAPI = [];
 		foreach( $accessibleWikis as $wiki => $data ) {
+			if( isset( $data['disabled'] ) ) continue;
 			$intList[$data['i18nsourcename']][$wiki] = "$wiki - {{int:Project-localized-name-$wiki}}";
 			$intListAPI[$data['i18nsourcename']] = $data['i18nsource'];
 			if( !isset( $wikis[$data['i18nsourcename'] . $wiki . "name"] ) ) $reloadData = true;

--- a/app/src/html/Includes/pagefunctions.php
+++ b/app/src/html/Includes/pagefunctions.php
@@ -4779,6 +4779,7 @@ function loadRunPages( &$jsonOut = false ) {
 		unset( $logData[count( $logData ) - 1] );
 		loadLogUsers( $logData );
 		foreach( $accessibleWikis as $wiki => $data ) {
+			if( isset( $data['disabled'] ) ) continue;
 			if( $data['runpage'] === true ) {
 				unset( $lastEntry );
 				foreach( $logData as $logEntry ) {

--- a/app/src/html/index.php
+++ b/app/src/html/index.php
@@ -319,6 +319,7 @@ $tmp = $accessibleWikis;
 unset( $tmp[WIKIPEDIA] );
 $elementText = "";
 foreach( $tmp as $wiki => $info ) {
+	if( isset( $info['disabled'] ) ) continue;
 	$urlbuilder = $loadedArguments;
 	unset( $urlbuilder['action'], $urlbuilder['token'], $urlbuilder['checksum'] );
 	$urlbuilder['wiki'] = $wiki;

--- a/app/src/html/loader.php
+++ b/app/src/html/loader.php
@@ -81,6 +81,8 @@ if( $setWikiFromReferal === true && WIKIPEDIA != $defaultWiki ) {
 	$_SESSION['setwiki'] = WIKIPEDIA;
 }
 
+if( $_SESSION['wiki'] != $_SESSION['setwiki'] ) $_SESSION['previouswiki'] = $_SESSION['wiki'];
+
 session_write_close();
 require_once( 'Includes/OAuth.php' );
 require_once( 'Includes/DB2.php' );


### PR DESCRIPTION
Force a redirect back to the last accessed, or default set wiki when trying to access a wiki that is either closed off, or has a broken OAuth setup.
Automatically disable the wiki on detection of a broken or closed OAuth setup.
Delist the wiki from the UI for disabled wikis.
Protect active user session from being broken when attempting to access a broken wiki.