### PR TITLE
Add current wiki as subheader on Wiki Config

### DIFF
--- a/app/src/html/Templates/wikiconfig.html
+++ b/app/src/html/Templates/wikiconfig.html
@@ -1,5 +1,6 @@
 <div class="page-header">
 	<h1>{{{configurewikihead}}}</h1>
+	<h2>{{{{currentwiki}}}}</h2>
 </div>
 <div class="container-fluid">
 	<div class="row">


### PR DESCRIPTION
The "Configure" page is linked prominently via the InternetArchiveBot header on our global user page, and it may not be intuitive which wiki is being configured. Thus I would like to display it more prominently.