### PR TITLE
Adding msg for not posting to talk page to i18n

### DIFF
--- a/app/src/html/i18n/en.json
+++ b/app/src/html/i18n/en.json
@@ -11,7 +11,7 @@
   "runbotmenutitleanalysis": "Analyze a page",
   "manageurlmenutitle": "Manage URL Data",
   "manageurlmenutitlesingle": "Manage individual URLs",
-  "manageurlmenutitledomain": "Manage entire domains",
+  "manageurlmenutitledomain": "Manage entire domaQins",
   "bugreportmenutitle": "Report Problem",
   "bugreportmenutitlefalsepositive": "Report false positive",
   "bugreportmenutitlerealbug": "Report other problems",
@@ -812,5 +812,6 @@
   "lockoutWarningHeader": "Interface Disabled",
   "lockoutWarning": "The interface is disabled, but you are in override mode. To deactivate the override, sign out and sign back in.",
   "inlang_tags": "In lang tags",
-  "inlang_tagsplaceholder": "This is a comma seperated list of templates that identify the language of a given reference.  Usually {{in lang}}."
+  "inlang_tagsplaceholder": "This is a comma seperated list of templates that identify the language of a given reference.  Usually {{in lang}}.",
+  "do_not_use_this_talk_page": "Do not post to this talk page. This talk page is not actively monitored. Please instead post to [[:m:User talk:InternetArchiveBot]]. We will respond there."
 }

--- a/app/src/html/i18n/en.json
+++ b/app/src/html/i18n/en.json
@@ -11,7 +11,7 @@
   "runbotmenutitleanalysis": "Analyze a page",
   "manageurlmenutitle": "Manage URL Data",
   "manageurlmenutitlesingle": "Manage individual URLs",
-  "manageurlmenutitledomain": "Manage entire domaQins",
+  "manageurlmenutitledomain": "Manage entire domains",
   "bugreportmenutitle": "Report Problem",
   "bugreportmenutitlefalsepositive": "Report false positive",
   "bugreportmenutitlerealbug": "Report other problems",

--- a/app/src/html/i18n/qqq.json
+++ b/app/src/html/i18n/qqq.json
@@ -590,5 +590,6 @@
 	"lockoutWarningHeader": "Subject header",
 	"lockoutWarning": "Warning message",
 	"inlang_tags": "Textbox header",
-	"inlang_tagsplaceholder": "Textbox placeholder"
+	"inlang_tagsplaceholder": "Textbox placeholder",
+	"do_not_use_this_talk_page": "Warning message posted to the bot's talk pages to direct users to the bot's talk page on Meta-Wiki"
 }


### PR DESCRIPTION
Sometimes, users post to talk pages that have soft redirects (to our Meta talk page) on them. Hard redirects between wikis is not possible. The soft redirect is apparently not clear enough in some instances. Therefore, we need a much more unambiguous message directing people to the right place.

For this message to be most effective, it should be in the language of the wiki it is being posted to. This patch therefore adds a "do not post to this talk page" message to our i18n project. This message will not be exposed through IABot's management interface, but this actively puts the string in front of translators so that we have a ready source of translations to go to.