### PR TITLE
Count symbols instead of bytes for proper vertical alignment

### DIFF
--- a/app/src/Core/generator.php
+++ b/app/src/Core/generator.php
@@ -525,10 +525,10 @@ class DataGenerator {
 					if( $mArray['link_template']['format'] == "multiline-pretty" ) {
 						$strlen = 0;
 						foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-							$strlen = max( $strlen, strlen( $parameter ) );
+							$strlen = max( $strlen, mb_strlen( $parameter ) );
 						}
 						foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-							$ttout .= " |" . str_pad( $parameter, $strlen, " " ) . " = $value\n";
+							$ttout .= " |$parameter" . str_repeat( " ", $strlen - mb_strlen( $parameter ) ) . " = $value\n";
 						}
 					} else foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
 						$ttout .= "|" . str_replace( "{key}", $parameter,
@@ -626,10 +626,10 @@ class DataGenerator {
 				if( $mArray['link_template']['format'] == "multiline-pretty" ) {
 					$strlen = 0;
 					foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-						$strlen = max( $strlen, strlen( $parameter ) );
+						$strlen = max( $strlen, mb_strlen( $parameter ) );
 					}
 					foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-						$out .= " |" . str_pad( $parameter, $strlen, " " ) . " = $value\n";
+						$out .= " |$parameter" . str_repeat( " ", $strlen - mb_strlen( $parameter ) ) . " = $value\n";
 					}
 				} else foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
 					$out .= "|" . str_replace( "{key}", $parameter,
@@ -651,10 +651,10 @@ class DataGenerator {
 			if( $mArray['link_template']['format'] == "multiline-pretty" ) {
 				$strlen = 0;
 				foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-					$strlen = max( $strlen, strlen( $parameter ) );
+					$strlen = max( $strlen, mb_strlen( $parameter ) );
 				}
 				foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
-					$out .= " |" . str_pad( $parameter, $strlen, " " ) . " = $value\n";
+					$out .= " |$parameter" . str_repeat( " ", $strlen - mb_strlen( $parameter ) ) . " = $value\n";
 				}
 			} else foreach( $mArray['link_template']['parameters'] as $parameter => $value ) {
 				$out .= "|" . str_replace( "{key}", $parameter,


### PR DESCRIPTION
This attempts to correct the issue with wrong vertical formatting of templates using Unicode (non-ASCII) parameter names, see [the report](https://meta.wikimedia.org/wiki/User_talk:InternetArchiveBot#Breaks_existing_code_style) at Meta-Wiki and the Phabricator task [T322797](https://phabricator.wikimedia.org/T322797).