### PR TITLE
Add a space to a message

### DIFF
--- a/app/src/html/i18n/en.json
+++ b/app/src/html/i18n/en.json
@@ -747,7 +747,7 @@
   "runpages": "Bot runpages",
   "enabled": "Enabled",
   "disabled": "Disabled",
-  "gotorunpage": "Goto runpage",
+  "gotorunpage": "Go to runpage",
   "runpagedisabled": "Run page is disabled",
   "enable": "Enable",
   "disable": "Disable",


### PR DESCRIPTION
"Goto" exists in some programming languages,
but in usual English, it's written with a space.