### PR TITLE
Fix perma.cc archive URL handling (long form + dead-link generation)

### DIFF
--- a/app/src/Core/APII.php
+++ b/app/src/Core/APII.php
@@ -4492,57 +4492,86 @@ class API {
 	 * @author    Maximilian Doerr (Cyberpower678)
 	 */
 	public static function resolvePermaCCURL( $url, $force ) {
-		permaccurlbegin:
 		$returnArray = [];
-		if( preg_match( '/\/\/perma(?:-archives\.org|\.cc)(?:\/warc)?\/([^\s\/]*)(\/\S*)?/i', $url, $match ) ) {
+		$code = false;
 
-			if( !is_numeric( $match[1] ) ) {
-				if( !$force && ( $newURL = DB::accessArchiveCache( $url ) ) !== false ) {
-					$url = $newURL;
-					$fastResolve = true;
-					goto permaccurlbegin;
-				}
-				$queryURL = "https://api.perma.cc/v1/public/archives/" . $match[1] . "/";
-				if( IAVERBOSE ) echo "Making query: $queryURL\n";
-				$metricsArray = [
-					'name'               => WIKIFARM,
-					'group_fields'       => [
-						'ep'   => 'permacc',
-						'ract' => 'resolve_archive',
-						'sact' => '',
-						'cm'   => "APII::resolvePermaCCURL()"
-					],
-					'aggregation_fields' => [
-
-					]
-				];
-				$data = self::makeHTTPRequest( $queryURL, [], false, false, [], [], $metricsArray );
-				$data = json_decode( $data, true );
-				if( is_null( $data ) ) return $returnArray;
-				if( ( $returnArray['archive_time'] =
-						strtotime( $data['capture_time'] ) ) === false ) {
-					$returnArray['archive_time'] =
-						strtotime( $data['creation_timestamp'] );
-				}
-
-				$returnArray['url'] = $data['url'];
-				$returnArray['archive_host'] = "permacc";
-				$returnArray['archive_url'] =
-					"https://perma-archives.org/warc/" . date( 'YmdHms', $returnArray['archive_time'] ) . "/" .
-					$returnArray['url'];
-				if( $url != $returnArray['archive_url'] ) $returnArray['convert_archive_url'] = true;
-				DB::accessArchiveCache( $url, $returnArray['archive_url'] );
-				$returnArray['fast_resolve'] = false;
+		// Modern short URL:  https://perma.cc/XXXX-XXXX
+		// The code is extracted independently of any trailing "?url=..." long form or path, so the
+		// long form recommended by the enwiki citation RfC is accepted rather than rejected.
+		if( preg_match( '/\/\/perma\.cc\/([0-9A-Za-z]{4}-[0-9A-Za-z]{4})/i', $url, $match ) ) {
+			$code = strtoupper( $match[1] );
+		} elseif( preg_match( '/\/\/perma-archives\.org(?:\/warc)?\/([^\s\/]+)(\/\S*)?/i', $url, $match ) ) {
+			// Legacy warc URL. First path segment is either a perma.cc code or a bare timestamp.
+			if( preg_match( '/^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$/', $match[1] ) ) {
+				$code = strtoupper( $match[1] );
 			} else {
-				$returnArray['archive_url'] = "https://perma-archives.org/warc/" . $match[1] . $match[2];
-				$returnArray['url'] = $match[2];
+				// Timestamp-only legacy snapshot: no opaque perma.cc code is recoverable from a
+				// timestamp, so the deprecated form is preserved as-is. Such records are migrated
+				// forward by supplying the modern perma.cc code directly (e.g. via the API).
+				$returnArray['archive_url'] = "https://perma-archives.org/warc/" . $match[1] . ( $match[2] ?? "" );
+				$returnArray['url'] = ltrim( $match[2] ?? "", "/" );
 				$returnArray['archive_time'] = strtotime( $match[1] );
 				$returnArray['archive_host'] = "permacc";
-				if( isset( $fastResolve ) ) $returnArray['fast_resolve'] = $fastResolve;
-				else $returnArray['fast_resolve'] = false;
-				if( $returnArray['fast_resolve'] ) $returnArray['convert_archive_url'] = true;
+				$returnArray['fast_resolve'] = false;
+
+				return $returnArray;
 			}
 		}
+
+		if( $code === false ) return $returnArray;
+
+		$returnArray['archive_host'] = "permacc";
+
+		// Resolve the original URL and capture time from the perma.cc public API.
+		$queryURL = "https://api.perma.cc/v1/public/archives/" . $code . "/";
+		if( IAVERBOSE ) echo "Making query: $queryURL\n";
+		$metricsArray = [
+			'name'               => WIKIFARM,
+			'group_fields'       => [
+				'ep'   => 'permacc',
+				'ract' => 'resolve_archive',
+				'sact' => '',
+				'cm'   => "APII::resolvePermaCCURL()"
+			],
+			'aggregation_fields' => [
+
+			]
+		];
+		$data = json_decode( self::makeHTTPRequest( $queryURL, [], false, false, [], [], $metricsArray ), true );
+
+		$originalURL = false;
+		if( is_array( $data ) && !empty( $data['url'] ) ) {
+			if( ( $returnArray['archive_time'] = strtotime( $data['capture_time'] ?? "" ) ) === false ) {
+				$returnArray['archive_time'] = strtotime( $data['creation_timestamp'] ?? "" );
+			}
+			$originalURL = $data['url'];
+		} elseif( preg_match( '/[?&]url=(\S+)/i', $url, $uMatch ) ) {
+			// API unavailable, but the caller supplied the "?url=" long form; recover it.
+			$originalURL = urldecode( $uMatch[1] );
+			$returnArray['archive_partially_validated'] = true;
+		} else {
+			$returnArray['archive_partially_validated'] = true;
+		}
+
+		// Canonical archive URL is the perma.cc long form (per enwiki citation policy):
+		//     https://perma.cc/<CODE>?url=<original>
+		// Only "?", "=", "&" and "#" inside the embedded original URL are percent-encoded, so they
+		// cannot be mistaken for perma.cc's own query/fragment delimiters. Everything else is left
+		// intact, and already-encoded sequences are not touched (the literal chars simply aren't present).
+		if( $originalURL !== false ) {
+			$returnArray['url'] = $originalURL;
+			$returnArray['archive_url'] = "https://perma.cc/" . $code . "?url=" .
+			                              str_replace( [ "?", "=", "&", "#" ], [ "%3F", "%3D", "%26", "%23" ],
+			                                           $originalURL );
+		} else {
+			// No original URL recoverable; store the bare short form.
+			$returnArray['archive_url'] = "https://perma.cc/" . $code;
+		}
+
+		// Signal a citation rewrite whenever the input differs from the canonical form (e.g. a legacy
+		// perma-archives.org URL, a bare short URL, or a differently-encoded long form).
+		if( $url != $returnArray['archive_url'] ) $returnArray['convert_archive_url'] = true;
+		$returnArray['fast_resolve'] = false;
 
 		return $returnArray;
 	}


### PR DESCRIPTION
## Summary

Fixes two bugs in perma.cc archive-URL handling (surfaced via the `modifyurl` API while
migrating legacy `perma-archives.org` records to modern `perma.cc` URLs), plus the related
generation of dead perma links into articles. All three share one root cause in
`APII::resolvePermaCCURL()`.

`perma-archives.org` is deprecated and no longer resolves; the modern, working form is
`https://perma.cc/<CODE>`, and the enwiki citation guidance recommends the long form
`https://perma.cc/<CODE>?url=<original>`.

## Bug 1 — `invalidarchive` on any perma.cc URL with a query string

`modifyurl` (even with `overridearchivevalidation=1`) rejects
`https://perma.cc/9ADD-MG9L?url=https://example.com/...` as `invalidarchive`, while the bare
`https://perma.cc/9ADD-MG9L` is accepted. The code-extraction regex
(`([^\s\/]*)`) swallowed the `?url=...` query into the "code", so the perma.cc API lookup was
made with a garbage code and failed → `isArchive()` returned false → `invalidarchive`.

## Bug 2 — accepted `modifyurl` calls silently do not persist

A bare perma.cc URL returns `"result": "success"` and logs a history entry, but the stored
`archive` field never changes (confirmed via `searchurldata`). `resolvePermaCCURL()` rewrote the
submitted `perma.cc/CODE` back into the deprecated `perma-archives.org/warc/<time>/<url>` form —
which equals the legacy value already stored — so the update was a no-op. Because both storage
and article output consume this function's `archive_url`, the same defect also made IABot
**write dead `perma-archives.org` links into articles**.

## Fix

`resolvePermaCCURL()` now:

- extracts the `CODE` independently of any trailing `?url=` / path / `#` suffix, so the long form
  is accepted (fixes Bug 1);
- resolves the original URL and capture time from the perma.cc public API;
- returns the modern canonical **long form** `https://perma.cc/<CODE>?url=<original>`,
  percent-encoding only `?`, `=`, `&`, `#` within the embedded original URL so they cannot be
  confused with perma.cc's own query/fragment delimiters (everything else left intact;
  already-encoded sequences are not double-encoded) — fixes Bug 2 and dead-link generation;
- still accepts legacy `perma-archives.org` input and sets `convert_archive_url`, so existing
  citations migrate forward on reprocessing;
- falls back to a partially-validated bare short URL if the perma.cc API is unavailable.

## Test case

- `urlid` 100032387
- source: `https://www.bnm.gov.my/index.php?ch=en_announcement&pg=en_announcement&ac=19&bb=file`
- legacy archive: `https://perma-archives.org/warc/20201125211106/https://www.bnm.gov.my/...`
- submitted: `https://perma.cc/9ADD-MG9L` → now stores/renders
  `https://perma.cc/9ADD-MG9L?url=https://www.bnm.gov.my/index.php%3Fch%3Den_announcement%26pg%3Den_announcement%26ac%3D19%26bb%3Dfile`

## Notes / scope

- Change is isolated to `APII::resolvePermaCCURL()`. The legacy `perma-archives.org` templates in
  `CiteMap.php` / `parse.php` are left in place for reading old citations (they reconstruct from
  timestamp+url and cannot represent an opaque perma.cc code).
- Verified: `php -l` clean; URL parsing + long-form encoding unit-tested offline against the cases
  above. The live perma.cc API round-trip / full DB write path were reasoned through but not
  executed in my environment — worth a maintainer sanity check against a live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
