### PR TITLE
Fix perma.cc archive URL handling: emit modern perma.cc long form, drop dead perma-archives.org

### DIFF
--- a/app/src/Core/APII.php
+++ b/app/src/Core/APII.php
@@ -4492,57 +4492,102 @@ class API {
 	 * @author    Maximilian Doerr (Cyberpower678)
 	 */
 	public static function resolvePermaCCURL( $url, $force ) {
-		permaccurlbegin:
-		$returnArray = [];
-		if( preg_match( '/\/\/perma(?:-archives\.org|\.cc)(?:\/warc)?\/([^\s\/]*)(\/\S*)?/i', $url, $match ) ) {
+		// Return a cached resolution when available (avoids re-querying the perma.cc API, matching
+		// the caching design of the other resolvers). Entries are serialized result arrays; a legacy
+		// plain-string entry from the previous perma-archives.org behaviour fails to unserialize (or
+		// is not in the modern perma.cc form) and is treated as a miss, so it is re-resolved and
+		// overwritten with the current form.
+		if( !$force && ( $cached = DB::accessArchiveCache( $url ) ) !== false ) {
+			$data = @unserialize( $cached );
+			if( is_array( $data ) && !empty( $data['archive_url'] ) &&
+			    strpos( $data['archive_url'], "//perma.cc/" ) !== false ) {
+				$data['fast_resolve'] = true;
 
-			if( !is_numeric( $match[1] ) ) {
-				if( !$force && ( $newURL = DB::accessArchiveCache( $url ) ) !== false ) {
-					$url = $newURL;
-					$fastResolve = true;
-					goto permaccurlbegin;
-				}
-				$queryURL = "https://api.perma.cc/v1/public/archives/" . $match[1] . "/";
-				if( IAVERBOSE ) echo "Making query: $queryURL\n";
-				$metricsArray = [
-					'name'               => WIKIFARM,
-					'group_fields'       => [
-						'ep'   => 'permacc',
-						'ract' => 'resolve_archive',
-						'sact' => '',
-						'cm'   => "APII::resolvePermaCCURL()"
-					],
-					'aggregation_fields' => [
-
-					]
-				];
-				$data = self::makeHTTPRequest( $queryURL, [], false, false, [], [], $metricsArray );
-				$data = json_decode( $data, true );
-				if( is_null( $data ) ) return $returnArray;
-				if( ( $returnArray['archive_time'] =
-						strtotime( $data['capture_time'] ) ) === false ) {
-					$returnArray['archive_time'] =
-						strtotime( $data['creation_timestamp'] );
-				}
-
-				$returnArray['url'] = $data['url'];
-				$returnArray['archive_host'] = "permacc";
-				$returnArray['archive_url'] =
-					"https://perma-archives.org/warc/" . date( 'YmdHms', $returnArray['archive_time'] ) . "/" .
-					$returnArray['url'];
-				if( $url != $returnArray['archive_url'] ) $returnArray['convert_archive_url'] = true;
-				DB::accessArchiveCache( $url, $returnArray['archive_url'] );
-				$returnArray['fast_resolve'] = false;
-			} else {
-				$returnArray['archive_url'] = "https://perma-archives.org/warc/" . $match[1] . $match[2];
-				$returnArray['url'] = $match[2];
-				$returnArray['archive_time'] = strtotime( $match[1] );
-				$returnArray['archive_host'] = "permacc";
-				if( isset( $fastResolve ) ) $returnArray['fast_resolve'] = $fastResolve;
-				else $returnArray['fast_resolve'] = false;
-				if( $returnArray['fast_resolve'] ) $returnArray['convert_archive_url'] = true;
+				return $data;
 			}
 		}
+
+		$returnArray = [];
+		$code = false;
+		$legacyOriginal = false;
+
+		// Modern short URL:  https://perma.cc/XXXX-XXXX
+		// The code is extracted independently of any trailing "?url=..." long form or path, so the
+		// long form recommended by the enwiki citation RfC is accepted rather than rejected.
+		if( preg_match( '/\/\/perma\.cc\/([0-9A-Za-z]{4}-[0-9A-Za-z]{4})/i', $url, $match ) ) {
+			$code = strtoupper( $match[1] );
+		} elseif( preg_match( '/\/\/perma-archives\.org(?:\/warc)?\/([^\s\/]+)(\/\S*)?/i', $url, $match ) ) {
+			// Legacy warc URL. First path segment is either a perma.cc code or a bare timestamp.
+			if( preg_match( '/^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$/', $match[1] ) ) {
+				$code = strtoupper( $match[1] );
+				// The original URL is present in the legacy path; keep it so this migrates to a
+				// full long form even without a "?url=" payload.
+				if( !empty( $match[2] ) ) $legacyOriginal = ltrim( $match[2], "/" );
+			} else {
+				// Timestamp-only legacy snapshot: no opaque perma.cc code is recoverable from a
+				// timestamp, so the deprecated form is preserved as-is. Such records are migrated
+				// forward by supplying the modern perma.cc code directly (e.g. via the API).
+				$returnArray['archive_url'] = "https://perma-archives.org/warc/" . $match[1] . ( $match[2] ?? "" );
+				$returnArray['url'] = ltrim( $match[2] ?? "", "/" );
+				$returnArray['archive_time'] = strtotime( $match[1] );
+				$returnArray['archive_host'] = "permacc";
+				$returnArray['fast_resolve'] = false;
+
+				return $returnArray;
+			}
+		}
+
+		if( $code === false ) return $returnArray;
+
+		$returnArray['archive_host'] = "permacc";
+
+		// perma.cc sits behind Cloudflare bot-mitigation, so api.perma.cc is not reachable from the
+		// wget/curl HTTP layer and is NOT queried. Everything is resolved from the URL itself:
+		//   - the original URL from the long-form "?url=" payload; and
+		//   - the capture time from an optional "&ts=YYYYMMDDHHMMSS" hint, keeping the long form
+		//     self-describing (so it also survives being re-read from article wikitext later).
+		$originalURL = false;
+		if( preg_match( '/[?&]url=([^&\s]+)/i', $url, $uMatch ) ) {
+			$originalURL = urldecode( $uMatch[1] );
+		} elseif( $legacyOriginal !== false ) {
+			$originalURL = $legacyOriginal;
+		}
+		if( preg_match( '/[?&]ts=([0-9]{4,14})/i', $url, $tMatch ) ) {
+			$tsRaw = str_pad( $tMatch[1], 14, "0" );
+			$tsObj = DateTime::createFromFormat( 'YmdHis', $tsRaw, new DateTimeZone( 'UTC' ) );
+			if( $tsObj !== false ) $returnArray['archive_time'] = $tsObj->getTimestamp();
+		}
+
+		// Canonical archive URL is the perma.cc long form (per enwiki citation policy):
+		//     https://perma.cc/<CODE>?url=<original>[&ts=<YYYYMMDDHHMMSS>]
+		// Only "?", "=", "&" and "#" inside the embedded original URL are percent-encoded, so they
+		// cannot be mistaken for perma.cc's own query/fragment delimiters. Everything else is left
+		// intact, and already-encoded sequences are not touched (the literal chars simply aren't present).
+		if( $originalURL !== false ) {
+			$returnArray['url'] = $originalURL;
+			$returnArray['archive_url'] = "https://perma.cc/" . $code . "?url=" .
+			                              str_replace( [ "?", "=", "&", "#" ], [ "%3F", "%3D", "%26", "%23" ],
+			                                           $originalURL );
+			if( !empty( $returnArray['archive_time'] ) ) {
+				$returnArray['archive_url'] .= "&ts=" . gmdate( 'YmdHis', $returnArray['archive_time'] );
+			}
+		} else {
+			// No original URL recoverable (bare short form, and the API is unusable).
+			$returnArray['archive_url'] = "https://perma.cc/" . $code;
+		}
+
+		// No capture time available -> flag as partially validated so isArchive() accepts it without
+		// a timestamp and the write path stores a blank (NULL) archive date rather than a bogus one.
+		if( empty( $returnArray['archive_time'] ) ) $returnArray['archive_partially_validated'] = true;
+
+		// Signal a citation rewrite whenever the input differs from the canonical form (e.g. a legacy
+		// perma-archives.org URL, a bare short URL, or a differently-encoded long form).
+		if( $url != $returnArray['archive_url'] ) $returnArray['convert_archive_url'] = true;
+
+		// Cache the resolved result (serialized). There is no API call to avoid, but caching keeps
+		// repeat resolves and legacy->modern migrations consistent, matching the other resolvers.
+		DB::accessArchiveCache( $url, serialize( $returnArray ) );
+		$returnArray['fast_resolve'] = false;
 
 		return $returnArray;
 	}

--- a/app/src/html/Includes/actionfunctions.php
+++ b/app/src/html/Includes/actionfunctions.php
@@ -1594,7 +1594,8 @@ function changeURLData( &$jsonOut = false ) {
 						    $checkIfDead->sanitizeURL( $loadedArguments['url'], true )
 						) {
 							$toChange['archive_url'] = $dbObject->sanitize( $data['archive_url'] );
-							$toChange['archive_time'] = date( 'Y-m-d H:i:s', $data['archive_time'] );
+							$toChange['archive_time'] = ( empty( $data['archive_time'] ) || !is_numeric( $data['archive_time'] ) ) ?
+								null : date( 'Y-m-d H:i:s', $data['archive_time'] );
 							if( $result['has_archive'] != 1 ) $toChange['has_archive'] = 1;
 							if( $result['archived'] != 1 ) $toChange['archived'] = 1;
 							if( $result['reviewed'] != 1 ) $toChange['reviewed'] = 1;
@@ -1614,7 +1615,8 @@ function changeURLData( &$jsonOut = false ) {
 							return false;
 						} else {
 							$toChange['archive_url'] = $dbObject->sanitize( $data['archive_url'] );
-							$toChange['archive_time'] = date( 'Y-m-d H:i:s', $data['archive_time'] );
+							$toChange['archive_time'] = ( empty( $data['archive_time'] ) || !is_numeric( $data['archive_time'] ) ) ?
+								null : date( 'Y-m-d H:i:s', $data['archive_time'] );
 							if( $result['has_archive'] != 1 ) $toChange['has_archive'] = 1;
 							if( $result['archived'] != 1 ) $toChange['archived'] = 1;
 							if( $result['reviewed'] != 1 ) $toChange['reviewed'] = 1;


### PR DESCRIPTION
## Summary

perma.cc archives are mishandled in three related ways, all rooted in `APII::resolvePermaCCURL()`:
a validation bug, a silent non-persistence bug, and generation of dead archive links into
articles. This rewrites the resolver to produce the modern, working perma.cc URL and removes a
dependency on the perma.cc API that is no longer reachable.

Background: `perma-archives.org` is deprecated and no longer resolves. The working forms are the
short `https://perma.cc/<CODE>` and the enwiki-recommended long form
`https://perma.cc/<CODE>?url=<original>&ts=<timestamp>`.

## Bug 1 — `invalidarchive` on any perma.cc URL with a query string

`modifyurl` (even with `overridearchivevalidation=1`) rejects
`https://perma.cc/9ADD-MG9L?url=https://example.com/…` as `invalidarchive`, while the bare
`https://perma.cc/9ADD-MG9L` is accepted. The code-extraction regex `([^\s\/]*)` swallowed the
`?url=…` query into the "code", so resolution failed.

## Bug 2 — accepted `modifyurl` calls silently did not persist

A bare perma.cc URL returned `"result": "success"` and logged a history entry, but the stored
`archive` field never changed (confirmed via `searchurldata`). The resolver rewrote the submitted
`perma.cc/<CODE>` back into the deprecated `perma-archives.org/warc/<time>/<url>` form — which
equalled the legacy value already stored — so the update was a no-op. Because both storage and
article output consume this function's `archive_url`, the same defect also made IABot **write dead
`perma-archives.org` links into articles**.

## perma.cc API is not usable (why the fix does not call it)

The previous resolver resolved a short code by querying `https://api.perma.cc/v1/public/archives/<code>/`.
That endpoint is behind Cloudflare bot-mitigation and returns a `403` challenge (`cf-mitigated:
challenge`) to non-browser clients — i.e. to IABot's wget/curl HTTP layer. So short-code resolution
was effectively already broken, and the fix does **not** depend on the API.

## Fix

`resolvePermaCCURL()` now resolves everything from the URL itself, with no external call:

- **Code** is extracted independently of any `?url=` / path / `#` suffix (fixes Bug 1).
- **Original URL** comes from the long-form `?url=` parameter, or, for a legacy
  `perma-archives.org/warc/<code>/<original>`, from the path (so legacy links migrate forward).
- **Capture time** comes from the `&ts=YYYYMMDDHHMMSS` parameter of the long form. If absent, the
  archive is marked partially validated and the date is left blank (NULL) rather than a bogus value.
- **Canonical output** is the long form `https://perma.cc/<CODE>?url=<original>&ts=<ts>`, with only
  `?`, `=`, `&`, `#` percent-encoded inside the embedded original URL (so they can't be confused
  with perma.cc's own delimiters); everything else is left intact and already-encoded sequences are
  not double-encoded. Resolution is idempotent (no citation churn on reparse).
- Legacy `perma-archives.org` input is still accepted and `convert_archive_url` is set so existing
  citations migrate forward. Timestamp-only legacy snapshots (no recoverable code) are preserved
  as-is.
- The author's serialized-result cache (`DB::accessArchiveCache`) is used as with the other
  resolvers; pre-existing plain-string `perma-archives.org` cache entries fail to unserialize and
  are treated as a miss, so they are re-resolved and overwritten with the modern form.

Also, `modifyurl` (`changeURLData`) now writes a NULL `archive_time` when no capture time is known,
instead of coercing to `1970-01-01`.

## Long-form format

The canonical archive URL follows the enwiki long-form recommendation,
`https://perma.cc/<CODE>?url=<original>&ts=<timestamp>`: `?url=` carries the original URL and `&ts=`
carries the capture time (`YYYYMMDDHHMMSS`). perma.cc identifies the snapshot by `<CODE>` alone and
ignores the extra query parameters, so the form resolves normally while remaining self-describing
for IABot (no API needed, and it survives being re-read from article wikitext).

## Files changed

- `app/src/Core/APII.php` — `resolvePermaCCURL()` rewrite.
- `app/src/html/Includes/actionfunctions.php` — NULL archive-date guard in `changeURLData`.

## Testing

- `php -l` clean on both files.
- URL parsing, `?=&#` encoding, `&ts=` parsing, idempotency, legacy→modern migration, and the
  cache accept/reject logic were verified with standalone harnesses.
- Not exercised against a live IABot instance (DB + full `modifyurl`/parse round-trip). A maintainer
  sanity check against a live instance is welcome.

## Reproduction / test case

- `urlid` 100032387
- source: `https://www.bnm.gov.my/index.php?ch=en_announcement&pg=en_announcement&ac=19&bb=file`
- legacy archive: `https://perma-archives.org/warc/20201125211106/https://www.bnm.gov.my/…`
- submit `https://perma.cc/9ADD-MG9L?url=<encoded original>&ts=20201125211106` → stored/rendered as
  the canonical long form; `searchurldata` then shows the perma.cc value (previously it stayed the
  legacy dead URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
